### PR TITLE
add 2 more commands

### DIFF
--- a/console_commands.html
+++ b/console_commands.html
@@ -123,6 +123,14 @@
                                 </tr>
                             </thead>
                             <tbody>
+				<tr>
+                                    <th scope="row">connect</th>
+                                    <td>connect 127.0.0.1:27017 (IP:Port)</td>
+									<td>X</td>
+                                    <td>✓</td>
+                                    <td>✓</td>
+                                    <td>Connect to specified IP and port.</td>
+                                </tr>
                                 <tr>
                                     <th scope="row">unlockstats</th>
                                     <td>unlockstats</td>

--- a/console_commands.html
+++ b/console_commands.html
@@ -179,6 +179,14 @@
                                     <td>✓</td>
                                     <td>Adjusts the yawspeed (Turn Right/Left) sensitivity.</td>
                                 </tr>
+				<tr>
+                                    <th scope="row">com_maxfps</th>
+                                    <td>com_maxfps "85"</td>
+									<td>X</td>
+                                    <td>✓</td>
+                                    <td>✓</td>
+                                    <td>Adjusts the FPS (this is only useful for doing a specific FPS)</td>
+                                </tr>
                                 <tr>
                                     <th scope="row">customtitle</th>
                                     <td>customtitle ^1Hello!</td>


### PR DESCRIPTION
these commands aren't super important and this doesn't have to get accepted but here's my reasoning for the two.

- connect
although the connect command is promoted a good amount of the time, i think it should still be in there because a player could read the console commands first and not even realize that this command existed. plus, its a pretty common command whether its for private match with friends or just straight up connecting to a server

- com_maxfps
idk if this is as important but you can set a specific fps and idk if players will care for it.

you can decline this merge if you feel like it, i just wanna see if any of this is important