### PR TITLE
remove Entry Point Not Found error

### DIFF
--- a/iw6x_errors.html
+++ b/iw6x_errors.html
@@ -238,22 +238,6 @@
                     </div>
                 </div>
                 <!-- Support Item Wrapper Ends-->
-
-
-                <!-- Support Item Starts -->
-                <div class="blog-item-wrapper wow fadeInUp" data-wow-delay="0.3s">
-                    <div class="blog-item-text">
-                        <p>
-                            <a class="anchor" id="GetDpiForWindow"></a>
-                            Q: Entry Point Not Found / The procedure entry point GetDpiForWindow could not be located in the dynamic link library [...]
-                        </p>
-                        <img src="https://i.imgur.com/3DeR8Sw.png" class="img-fluid">
-                        <p>
-                            A: Update to Windows 10.
-                        </p>
-                    </div>
-                </div>
-                <!-- Support Item Wrapper Ends-->
             </div>
         </div>
     </section>


### PR DESCRIPTION
Support for win 7, 8, 8.1 has been added, removing this from the IW6x error page.
