### PR TITLE
Updated Footer of Main Webpage to 2022

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -15,7 +15,7 @@ document.write('\
                         </ul>\
                     </div>\
                     <div class="site-info wow fadeInUp" data-wow-duration="1000ms" data-wow-delay="0.3s">\
-                        <p>All copyrights reserved &copy; 2021 - <a rel="nofollow" href="https://xlabs.dev">X Labs</a></p>\
+                        <p>All copyrights reserved &copy; 2022 - <a rel="nofollow" href="https://xlabs.dev">X Labs</a></p>\
                     </div>\
                 </div>\
             </div>\


### PR DESCRIPTION
## Updated Footer of Main Webpage to 2022

Please check the type of change your PR introduces:
<!--   HINT: these checkboxes can be checked like this: []    -->
- [x ] Code style update (formatting, renaming)


## What is the current behavior?
The Main Webpage Use to Show Copyright 2021 in footer 
![before](https://user-images.githubusercontent.com/47073516/150994114-02654f36-e286-414c-b745-c8973b4c642f.PNG)



## What is the new behavior?
The Main Webpage After the change shows 2022 in footer 

![after](https://user-images.githubusercontent.com/47073516/150994262-558b19f1-8c03-4fe4-b1ea-9e6397a0d736.PNG)

