### PR TITLE
Private games instructions for IW4x private games

### DIFF
--- a/iw4x_privatematch.html
+++ b/iw4x_privatematch.html
@@ -68,13 +68,21 @@
                 <!-- Support Item Starts -->
                 <div class="blog-item-wrapper wow fadeInUp" data-wow-delay="0.3s">
                     <div class="blog-item-text">
-                        <h3>Connecting to your friends:</h3>
+                        <h3>IW4x Multiplayer Private Match Guide</h3>
                         <ol>
                             <li>Go to <a href="https://ipchicken.com">here</a> and PM anyone who wants to join your IP Address.</li>
-                            <li>Start IW4x and select 'CREATE GAME' from the main menu.</li>
+                            <li>Start IW4x Multiplayer and select 'CREATE GAME' from the main menu.</li>
                             <li>Click 'START GAME'.</li>
                             <li>Tell anyone who wants to join, open the console by using the tilde key while at the main menu.</li>
                             <li>Get them to enter the following command, replacing 'HostsIPAddress' with the IP you previously sent him: <code>/connect HostsIPAddress:28960</code></li>
+                        </ol>
+                        <h3>IW4x Singleplayer/Spec Ops Private Match Guide</h3>
+                        <ol>
+                            <li>Go to <a href="https://ipchicken.com">here</a> and PM anyone who wants to join your IP Address.</li>
+                            <li>Start IW4x Singleplayer and select 'SPECIAL OPS' from the main menu.</li>
+                            <li>Click on 'TWO PLAYER ONLINE' and select a mission to get to the pre-match lobby.</li>
+                            <li>Tell anyone who wants to join to click on 'TWO PLAYER ONLINE' and afterward to open the console by using the tilde key.</li>
+                            <li>Get them to enter the following command after they clicked on 'TWO PLAYER ONLINE', replacing 'HostsIPAddress' with the IP you previously sent him: <code>/connect HostsIPAddress 28960</code></li>
                         </ol>
                         <h3>Failed to join:</h3>
                         <ol>
@@ -82,7 +90,9 @@
 
                             <li>Port Forward port "28960" UDP & TCP</li>
                             <li>You can find how to do this by Googling 'YourRouterName Port Forwarding'</li>
-                            <li>Note: If port forwarding is too complex, just stick to playing public servers, or maybe join an empty server so you have the same experience as a private game.</li>
+                            <li>Note for multiplayer: If port forwarding is too complex, just stick to playing on public servers, or maybe join an empty server so you have the same experience as a private game.</li>
+                            <li>Note for singleplayer/spec ops: Make sure the person connecting ran the command after clicking on 'TWO PLAYER ONLINE' or after selecting a mission. Joining from the main menu doesn't work.</li>
+                            <li>Note for singleplayer/spec ops: Make sure you respected the particular syntax singleplayer/spec ops uses with the connect command. Using <code>:</code> between the IP and the port will not work, you need to use a space, like this: <code>/connect HostsIPAddress 28960</code></li>
                         </ol>
                     </div>
                 </div>


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
<!--   HINT: these checkboxes can be checked like this: [x]    -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Other (please describe): documenting how to play private games on IW4x singleplayer/spec ops


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no documentation for it


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
It's now documented


## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
I tested multiple scenarios with 2 different persons, including @diamante0018 
We tested with/without port forwarding and multiple scenarios of how the client can join (internal/external console, while in main menu, while in two player online menu, while in a lobby he created after selecting a mission)
With the two person the result was the same: the client had to join after clicking on 'Two Player Online', while in this menu or any menu that comes after from selecting a mission for example. Connecting from the main menu did not work, the client can join the lobby but can't join the game and play